### PR TITLE
Add NextVersions() and String() methods

### DIFF
--- a/semver.go
+++ b/semver.go
@@ -6,7 +6,11 @@
 // parsing of Versions and (Version-)Ranges.
 package semver
 
-import "strconv"
+import (
+	"fmt"
+	"sort"
+	"strconv"
+)
 
 // Errors that are thrown when translating from a string.
 const (
@@ -254,4 +258,113 @@ func (t *Version) Minor() int32 {
 // it would return 3.
 func (t *Version) Patch() int32 {
 	return t.version[2]
+}
+
+// NextVersions returns a list of possible next versions after t. For each of
+// the three version points, pre-releases are given as options starting with
+// the minimum release type (-4 <= 0), and those release types are numbered
+// if numberedPre is true. Release types:
+//
+//   alpha: -4
+//   beta:  -3
+//   pre:   -2
+//   rc:    -1
+//   common: 0
+//
+// Thus, if you don't want any pre-release options, set minReleaseType to 0.
+func (t *Version) NextVersions(minReleaseType int, numberedPre bool) []*Version {
+	var next []*Version
+
+	if minReleaseType < alpha || minReleaseType > common {
+		return next
+	}
+
+	// if this is a pre-release, suggest next pre-releases or
+	// common of same version
+	for releaseType := t.version[idxReleaseType]; releaseType < common; releaseType++ {
+		if releaseType == t.version[idxReleaseType] {
+			if !numberedPre {
+				continue
+			}
+			ver := *t
+			ver.version[idxRelease]++
+			next = append(next, &ver)
+		} else {
+			ver := *t
+			ver.version[idxReleaseType] = releaseType
+			if numberedPre {
+				ver.version[idxRelease] = 1
+			} else {
+				ver.version[idxRelease] = 0
+			}
+			next = append(next, &ver)
+		}
+	}
+	if t.version[idxReleaseType] < common {
+		ver := *t
+		ver.version[idxReleaseType] = common
+		ver.version[idxRelease] = 0
+		next = append(next, &ver)
+	}
+
+	// if the current version is at least common release type,
+	// suggest patch or revision if not one of those already
+	if t.version[idxReleaseType] == common ||
+		t.version[idxReleaseType] == patch {
+		ver := *t
+		ver.version[idxReleaseType] = revision
+		ver.version[idxRelease] = 1
+		next = append(next, &ver)
+	}
+	if t.version[idxReleaseType] == common ||
+		t.version[idxReleaseType] == revision {
+		ver := *t
+		ver.version[idxReleaseType] = patch
+		ver.version[idxRelease] = 1
+		next = append(next, &ver)
+	}
+
+	for i := 0; i < 3; i++ {
+		// for each version point, iterate the release types within desired bounds
+		for releaseType := int32(minReleaseType); releaseType <= common; releaseType++ {
+			ver := *t
+			ver.version[i]++
+			for j := i + 1; j < 3; j++ {
+				ver.version[j] = 0 // when incrementing, reset next points to 0
+			}
+			if i == 2 && releaseType < common {
+				continue // patches seldom have pre-releases
+			}
+			ver.version[idxReleaseType] = releaseType
+			if releaseType < common {
+				if numberedPre {
+					ver.version[idxRelease] = 1
+				} else {
+					ver.version[idxRelease] = 0
+				}
+			}
+			next = append(next, &ver)
+		}
+	}
+
+	sort.Slice(next, func(a, b int) bool {
+		return next[a].Less(next[b])
+	})
+
+	return next
+}
+
+// String returns the string representation of t.
+func (t *Version) String() string {
+	s := fmt.Sprintf("%d.%d.%d", t.version[0], t.version[1], t.version[2])
+	if t.version[idxReleaseType] != common {
+		s += fmt.Sprintf("-%s", releaseDesc[int(t.version[idxReleaseType])])
+		if t.version[idxRelease] > 0 {
+			s += fmt.Sprintf(".%d", t.version[idxRelease])
+		}
+	}
+	if t.build != 0 {
+		s += fmt.Sprintf("+build%d", t.build)
+	}
+	return s
 }

--- a/semver_test.go
+++ b/semver_test.go
@@ -235,6 +235,164 @@ func TestVersion(t *testing.T) {
 	})
 }
 
+func TestNextVersions(t *testing.T) {
+	toStr := func(list []*Version) []string {
+		ss := make([]string, len(list))
+		for i := range list {
+			ss[i] = list[i].String()
+		}
+		return ss
+	}
+
+	Convey("NextVersions works with…", t, func() {
+
+		ver := "1.0.0"
+		Convey(ver, func() {
+			ver, err := NewVersion(ver)
+			So(err, ShouldBeNil)
+
+			Convey("Without pre-releases", func() {
+				next := toStr(ver.NextVersions(0, false))
+				So(next, ShouldResemble, []string{
+					"1.0.0-r.1",
+					"1.0.0-p.1",
+					"1.0.1",
+					"1.1.0",
+					"2.0.0",
+				})
+			})
+
+			Convey("With some pre-releases", func() {
+				next := toStr(ver.NextVersions(-2, false))
+				So(next, ShouldResemble, []string{
+					"1.0.0-r.1",
+					"1.0.0-p.1",
+					"1.0.1",
+					"1.1.0-pre",
+					"1.1.0-rc",
+					"1.1.0",
+					"2.0.0-pre",
+					"2.0.0-rc",
+					"2.0.0",
+				})
+			})
+
+			Convey("With some pre-releases and numbers", func() {
+				next := toStr(ver.NextVersions(-2, true))
+				So(next, ShouldResemble, []string{
+					"1.0.0-r.1",
+					"1.0.0-p.1",
+					"1.0.1",
+					"1.1.0-pre.1",
+					"1.1.0-rc.1",
+					"1.1.0",
+					"2.0.0-pre.1",
+					"2.0.0-rc.1",
+					"2.0.0",
+				})
+			})
+
+			Convey("With all pre-releases", func() {
+				next := toStr(ver.NextVersions(-4, false))
+				So(next, ShouldResemble, []string{
+					"1.0.0-r.1",
+					"1.0.0-p.1",
+					"1.0.1",
+					"1.1.0-alpha",
+					"1.1.0-beta",
+					"1.1.0-pre",
+					"1.1.0-rc",
+					"1.1.0",
+					"2.0.0-alpha",
+					"2.0.0-beta",
+					"2.0.0-pre",
+					"2.0.0-rc",
+					"2.0.0",
+				})
+			})
+		})
+
+		ver = "1.2.3"
+		Convey(ver, func() {
+			ver, err := NewVersion(ver)
+			So(err, ShouldBeNil)
+
+			Convey("Without pre-releases", func() {
+				next := toStr(ver.NextVersions(0, false))
+				So(next, ShouldResemble, []string{
+					"1.2.3-r.1",
+					"1.2.3-p.1",
+					"1.2.4",
+					"1.3.0",
+					"2.0.0",
+				})
+			})
+
+			Convey("With some pre-releases", func() {
+				next := toStr(ver.NextVersions(-2, false))
+				So(next, ShouldResemble, []string{
+					"1.2.3-r.1",
+					"1.2.3-p.1",
+					"1.2.4",
+					"1.3.0-pre",
+					"1.3.0-rc",
+					"1.3.0",
+					"2.0.0-pre",
+					"2.0.0-rc",
+					"2.0.0",
+				})
+			})
+
+			Convey("With all pre-releases", func() {
+				next := toStr(ver.NextVersions(-4, false))
+				So(next, ShouldResemble, []string{
+					"1.2.3-r.1",
+					"1.2.3-p.1",
+					"1.2.4",
+					"1.3.0-alpha",
+					"1.3.0-beta",
+					"1.3.0-pre",
+					"1.3.0-rc",
+					"1.3.0",
+					"2.0.0-alpha",
+					"2.0.0-beta",
+					"2.0.0-pre",
+					"2.0.0-rc",
+					"2.0.0",
+				})
+			})
+		})
+
+		ver = "1.2.0-beta2"
+		Convey(ver, func() {
+			ver, err := NewVersion(ver)
+			So(err, ShouldBeNil)
+
+			Convey("With all pre-releases and numbers", func() {
+				next := toStr(ver.NextVersions(-4, true))
+				So(next, ShouldResemble, []string{
+					"1.2.0-beta.3",
+					"1.2.0-pre.1",
+					"1.2.0-rc.1",
+					"1.2.0",
+					"1.2.1",
+					"1.3.0-alpha.1",
+					"1.3.0-beta.1",
+					"1.3.0-pre.1",
+					"1.3.0-rc.1",
+					"1.3.0",
+					"2.0.0-alpha.1",
+					"2.0.0-beta.1",
+					"2.0.0-pre.1",
+					"2.0.0-rc.1",
+					"2.0.0",
+				})
+			})
+		})
+
+	})
+}
+
 func TestVersionOrder(t *testing.T) {
 
 	Convey("Version 1.2.3-alpha4 should be…", t, func() {


### PR DESCRIPTION
This closes #5.

The `String()` method is definitely not entirely comprehensive (I didn't know what to do with "specifiers") but it should capture most version representations.

The `NextVersions()` method returns a `[]*semver.Version` in ascending order by version. It understands pre-releases and post-releases and allows you to customize them: whether they are numbered, and allows you to specify a "minimum" pre-release (like if you don't want any "-alpha" versions, only beta or pre, etc).